### PR TITLE
Fix body type inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ninjato
 [![Bintray version](https://api.bintray.com/packages/agoda/maven/ninjato/images/download.svg)](https://bintray.com/agoda/maven/ninjato)
-[![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3.21-blue.svg)](http://kotlinlang.org/)
+[![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3.30-blue.svg)](http://kotlinlang.org/)
 [![codecov](https://codecov.io/gh/agoda-com/ninjato/branch/master/graph/badge.svg)](https://codecov.io/gh/agoda-com/ninjato)
 
 Flexible and type-safe inline HTTP client for Android and Kotlin
@@ -92,6 +92,26 @@ Default types of return value include:
  - `ByteArray`
 
 For all custom types library has support of `BodyConverter`.
+
+IMPORTANT NOTE: there is an issue with the Kotlin compiler and inlining of delegates with reified types
+is not working as expected. That means that current syntax of passing your body is inconsistent.
+Right now if you will pass an instance of generic class to a body property, type arguments will be lost:
+
+```kotlin
+fun foo(generic: Generic<String>) = post {
+    body = generic // It will capture only class of the generic via generic.javaClass
+}
+```
+
+That puts the responsibility of inferring the type arguments on your serializing library. Gson is doing this fine.
+If you want library to capture actual type and forward it to your `BodyConverter.Factory`, please consider using
+the newly introduced extension function:
+
+```kotlin
+fun foo(generic: Generic<Stirng>) = post {
+    body = convert(generic)
+}
+```
 
 #### BodyConverter
 `BodyConverter` is a simple interface with a `convert` function from one to another.

--- a/core/src/main/kotlin/com/agoda/ninjato/Api.kt
+++ b/core/src/main/kotlin/com/agoda/ninjato/Api.kt
@@ -186,9 +186,8 @@ abstract class Api(
                 }
 
                 val retry = configurator.retryPolicy ?: retryPolicy ?: client.retryPolicy ?: throw throwable
-                val evaluation = retry.evaluate(request, throwable)
 
-                when (evaluation) {
+                when (val evaluation = retry.evaluate(request, throwable)) {
                     is Retry.DoNotRetry -> throw throwable
                     is Retry.WithDelay -> evaluation.delay()
                 }

--- a/core/src/main/kotlin/com/agoda/ninjato/misc/BodyExtensions.kt
+++ b/core/src/main/kotlin/com/agoda/ninjato/misc/BodyExtensions.kt
@@ -1,8 +1,30 @@
 package com.agoda.ninjato.misc
 
+import com.agoda.ninjato.converter.BodyConverter
+import com.agoda.ninjato.exception.MissingConverterException
 import com.agoda.ninjato.http.Body
 import com.agoda.ninjato.http.MediaType
 import com.agoda.ninjato.http.Parameters
+import com.agoda.ninjato.http.Request.Configurator.WithBody
+import com.agoda.ninjato.reflect.TypeReference.Companion.reifiedType
 
-fun formUrlEncoded(tail: Parameters.() -> Unit)
+inline fun WithBody.formUrlEncoded(tail: Parameters.() -> Unit)
         = Body(Parameters().apply(tail).resolve().toUrlEncoded(), MediaType.FormUrlEncoded())
+
+inline fun <reified T> WithBody.convert(body: T): Body {
+    var converted: Body? = null
+
+    for (factory in converterFactories.resolve()) {
+        val converter = factory.requestConverter(reifiedType<T>()) as? BodyConverter<T, Body>
+
+        if (converter != null) {
+            converted = converter.convert(body)
+            break
+        }
+    }
+
+    return converted ?: throw MissingConverterException(
+            fullUrl ?: endpointUrl!!,
+            T::class.java.simpleName ?: ""
+    )
+}

--- a/core/src/main/kotlin/com/agoda/ninjato/misc/UrlEncoder.kt
+++ b/core/src/main/kotlin/com/agoda/ninjato/misc/UrlEncoder.kt
@@ -3,6 +3,7 @@ package com.agoda.ninjato.misc
 import java.lang.StringBuilder
 import java.net.URLEncoder
 
+@PublishedApi
 internal fun Map<String, String>.toUrlEncoded(isSeparatorRequired: Boolean = false, isPrefixRequired: Boolean = false)
         = if (isEmpty()) "" else StringBuilder().apply {
     val map = this@toUrlEncoded

--- a/core/src/test/kotlin/com.agoda.ninjato/http/BodyTest.kt
+++ b/core/src/test/kotlin/com.agoda.ninjato/http/BodyTest.kt
@@ -2,7 +2,6 @@ package com.agoda.ninjato.http
 
 import com.agoda.ninjato.converter.BodyConverter
 import com.agoda.ninjato.converter.ConverterFactories
-import com.agoda.ninjato.misc.formUrlEncoded
 import org.junit.Test
 import java.lang.reflect.Type
 
@@ -71,16 +70,6 @@ class BodyTest {
 
         // Assert
         assert((delegate as Body).asString == "testify_body")
-
-        // Act
-        delegate = formUrlEncoded {
-            "a" to "test param !"
-            "b" to "c"
-        }
-
-        // Assert
-        assert((delegate as Body).asString == "a=test+param+%21&b=c")
-        assert((delegate as Body).mediaType is MediaType.FormUrlEncoded)
     }
 
 }

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -1,5 +1,5 @@
 ext.versions = [
-        kotlin          : '1.3.21',
+        kotlin          : '1.3.30',
         android         : '3.3.1',
         androidMaven    : '3.6.2',
         dokka           : '0.9.17',
@@ -14,7 +14,7 @@ ext.versions = [
         mockitoKotlin   : '1.6.0',
         rxjava          : '1.3.8',
         rxjava2         : '2.2.7',
-        ninjato         : '0.2.0'
+        ninjato         : '0.2.1'
 ]
 
 ext.androidVersions = [
@@ -58,5 +58,5 @@ ext.ninjato = [
         url             : 'https://github.com/agoda-com/ninjato',
         git             : 'https://github.com/agoda-com/ninjato.git',
         group           : 'com.agoda.ninjato',
-        version         : '0.2.0'
+        version         : '0.2.1'
 ]


### PR DESCRIPTION
We discovered that inlining and reified types do not work with delegates correctly, even though compiler allows such code easily. Right now for any request body type library will infer type `Object` and will look for converter for this type.
Even though it works for the most part, this is still a bug.
I will reach out Kotlin team to look into the issue and introduce temporal solution here.