### PR TITLE
Fixes on the aggregation of properties

### DIFF
--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -14,7 +14,7 @@ ext.versions = [
         mockitoKotlin   : '1.6.0',
         rxjava          : '1.3.8',
         rxjava2         : '2.2.7',
-        ninjato         : '0.2.2'
+        ninjato         : '0.2.3'
 ]
 
 ext.androidVersions = [
@@ -58,5 +58,5 @@ ext.ninjato = [
         url             : 'https://github.com/agoda-com/ninjato',
         git             : 'https://github.com/agoda-com/ninjato.git',
         group           : 'com.agoda.ninjato',
-        version         : '0.2.2'
+        version         : '0.2.3'
 ]

--- a/ninjato-core/src/main/kotlin/com/agoda/ninjato/converter/ConverterFactories.kt
+++ b/ninjato-core/src/main/kotlin/com/agoda/ninjato/converter/ConverterFactories.kt
@@ -16,7 +16,7 @@ class ConverterFactories {
     @PublishedApi
     internal var parent: ConverterFactories? = null
 
-    private val added: MutableList<BodyConverter.Factory> = LinkedList()
+    private val added = LinkedList<BodyConverter.Factory>()
 
     /**
      * Adds provided factory to the aggregation.
@@ -37,7 +37,6 @@ class ConverterFactories {
     }
 
     @PublishedApi
-    internal fun resolve(): MutableList<BodyConverter.Factory> {
-        return (parent?.resolve() ?: LinkedList()).apply { addAll(0, added) }
-    }
+    internal fun resolve(): List<BodyConverter.Factory>
+            = parent?.resolve()?.let { added.plus(it) } ?: added
 }

--- a/ninjato-core/src/main/kotlin/com/agoda/ninjato/http/Headers.kt
+++ b/ninjato-core/src/main/kotlin/com/agoda/ninjato/http/Headers.kt
@@ -56,8 +56,8 @@ class Headers {
     }
 
     @PublishedApi
-    internal fun resolve(): MutableMap<String, MutableList<String>>
-            = parent?.resolve()?.also { it.addAll(values) } ?: values
+    internal fun resolve(): Map<String, MutableList<String>>
+            = parent?.resolve()?.let { p -> p.toMutableMap().also { it.addAll(values) } } ?: values
 
     companion object {
         private const val COOKIE = "Cookie"

--- a/ninjato-core/src/main/kotlin/com/agoda/ninjato/http/Parameters.kt
+++ b/ninjato-core/src/main/kotlin/com/agoda/ninjato/http/Parameters.kt
@@ -36,6 +36,6 @@ class Parameters {
     }
 
     @PublishedApi
-    internal fun resolve(): MutableMap<String, String>
-            = parent?.resolve()?.also { it.putAll(values) } ?: values
+    internal fun resolve(): Map<String, String>
+            = parent?.resolve()?.let { p -> p.toMutableMap().also { it.putAll(values) } } ?: values
 }

--- a/ninjato-core/src/main/kotlin/com/agoda/ninjato/intercept/Interceptors.kt
+++ b/ninjato-core/src/main/kotlin/com/agoda/ninjato/intercept/Interceptors.kt
@@ -83,10 +83,10 @@ class Interceptors {
     }
 
     @PublishedApi
-    internal fun resolveRequest(): MutableList<RequestInterceptor>
-            = parent?.resolveRequest()?.also { it.addAll(0, request) } ?: request
+    internal fun resolveRequest(): List<RequestInterceptor>
+            = parent?.resolveRequest()?.let { request.plus(it) } ?: request
 
     @PublishedApi
-    internal fun resolveResponse(): MutableList<ResponseInterceptor>
-            = parent?.resolveResponse()?.also { it.addAll(0, response) } ?: response
+    internal fun resolveResponse(): List<ResponseInterceptor>
+            = parent?.resolveResponse()?.let { response.plus(it) } ?: response
 }


### PR DESCRIPTION
There were some problems with aggregation discovered by @tseglevskiy 
Apparently, when aggregating interceptors, the code would actually duplicate it during the aggregation.
This PR revises and fixes all problems with property aggregation by creating immutable copies during aggregation process.

Also bumps version to `0.2.3` to do hot fix release.